### PR TITLE
Fix on relation departure

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -18,19 +18,17 @@ from charms.reactive import not_unless
 from charmhelpers.core.hookenv import log
 
 class SolrProvides(RelationBase):
-    scope = scopes.SERVICE
+    scope = scopes.UNIT
 
     @hook('{provides:solr}-relation-joined')
     def joined(self):
         log("solr-interface-joined")
-        conversation = self.conversation()
-        conversation.set_state('{relation_name}.core.requested')
+        self.set_state('{relation_name}.core.requested')
 
     @hook('{provides:solr}-relation-{broken,departed}')
     def departed(self):
         log("solr-interface-broken")
-        conversation = self.conversation()
-        conversation.remove_state('{relation_name}.core.requested')
+        self.remove_state('{relation_name}.core.requested')
 
     @not_unless('{provides:solr}.core.requested')
     def provide_core(self, service, host, port, core):


### PR DESCRIPTION
When calling `juju remove-relation`
```
hook failed: "solr-interface-relation-broken" for <unit>
```

Logs returns
```
unit-apache-solr-0: 11:44:40 ERROR unit.apache-solr/0.juju-log solr-interface:38: Hook error:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-apache-solr-0/.venv/lib/python3.5/site-packages/charms/reactive/__init__.py", line 74, in main
    bus.dispatch(restricted=restricted_mode)
  File "/var/lib/juju/agents/unit-apache-solr-0/.venv/lib/python3.5/site-packages/charms/reactive/bus.py", line 379, in dispatch
    _invoke(hook_handlers)
  File "/var/lib/juju/agents/unit-apache-solr-0/.venv/lib/python3.5/site-packages/charms/reactive/bus.py", line 359, in _invoke
    handler.invoke()
  File "/var/lib/juju/agents/unit-apache-solr-0/.venv/lib/python3.5/site-packages/charms/reactive/bus.py", line 181, in invoke
    self._action(*args)
  File "/var/lib/juju/agents/unit-apache-solr-0/charm/hooks/relations/solr/provides.py", line 31, in departed
    self.remove_state('{relation_name}.core.requested')
  File "/var/lib/juju/agents/unit-apache-solr-0/.venv/lib/python3.5/site-packages/charms/reactive/relations.py", line 460, in remove_state
    self.conversation(scope).remove_state(state)
  File "/var/lib/juju/agents/unit-apache-solr-0/.venv/lib/python3.5/site-packages/charms/reactive/relations.py", line 431, in conversation
    raise ValueError('Unable to determine default scope: no current hook or global scope')
ValueError: Unable to determine default scope: no current hook or global scope
```

This quick fix avoid that error and provide the right scope.

ref #3 